### PR TITLE
remove duplicate macro import

### DIFF
--- a/templates/default_vhost.j2
+++ b/templates/default_vhost.j2
@@ -1,5 +1,4 @@
 {% include 'common_vhost.j2' %}
-{% import "macros.j2" as apache_macros with context %}
     <Directory {{apache_vhost_webroot}}>
         Options Indexes FollowSymLinks
         AllowOverride {{apache_vhost_allowoverride}}


### PR DESCRIPTION
This causes some problems with all jinja templates
and macros are not used in this file.