### PR TITLE
Conditionally prepend Wordfence WAF file in vhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Create Apache site configuration files.
 
+In `templates/wordpress_vhost.j2`, the variable `wordfence_waf_path` should point to `wordfence-waf.php` file which can be used to enable Wordfence Extended Protection. By default, the variable is undefined and is not used. If the variable is defined, the target file must exist or the page will be blank.
+
 ## License
 
 MIT

--- a/templates/wordpress_vhost.j2
+++ b/templates/wordpress_vhost.j2
@@ -12,6 +12,11 @@
         AllowOverride {{apache_vhost_allowoverride}}
         Order allow,deny
         allow from all
+{% if wordfence_waf_path is defined %}
+        <IfModule mod_php7.c>
+            php_value auto_prepend_file {{ wordfence_waf_path }}
+        </IfModule>
+{% endif %}
 {% if wordpress_webroot is defined and other_sites == [] %}
         <IfModule mod_rewrite.c>
             RewriteEngine On


### PR DESCRIPTION
The variable `wordfence_waf_path` points to Wordfence WAF file which is
used to enable Extended Protection.

Specifying the file in the virtual host configuration has the advantage
that it will only affect a certain site. If the value was specified in
php.ini it could have unwanted effects on other possibly unrelated
sites.

The variable does not have a default value in the role, so the file is
prepended only when it is explicitly defined. Please ensure the file
actually exists or the page will be blank.