### PR TITLE
Change wordpress vhost waf config to support php8

### DIFF
--- a/templates/wordpress_vhost.j2
+++ b/templates/wordpress_vhost.j2
@@ -13,7 +13,7 @@
         Order allow,deny
         allow from all
 {% if wordfence_waf_path is defined %}
-        <IfModule mod_php7.c>
+        <IfModule mod_php.c>
             php_value auto_prepend_file {{ wordfence_waf_path }}
         </IfModule>
 {% endif %}


### PR DESCRIPTION
The mod_php7.c module is renamed to mod_php.c starting at php8.